### PR TITLE
Fix `verlib2.__version__`, now using `importlib.metadata`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Added original `distutils/version.py` from Python 3.11.11.
   Because some custom version implementations derive from it,
   it is a good idea to have it around for Python 3.12 and higher.
+- Fixed `verlib2.__version__`, now using `importlib.metadata`.
 
 ## 2025-02-02 v0.2.1
 - Maintenance release including a minor change about a `mypy`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dynamic = [
 ]
 
 dependencies = [
+  "importlib-metadata; python_version<'3.8'",
 ]
 
 optional-dependencies.develop = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,12 +137,17 @@ show_missing = true
 
 [tool.mypy]
 packages = [ "verlib2" ]
-strict = true
-show_error_codes = true
+check_untyped_defs = true
 enable_error_code = [ "ignore-without-code", "redundant-expr", "truthy-bool" ]
 exclude = [
   "verlib2/distutils/version.py",
 ]
+ignore_missing_imports = true
+implicit_optional = true
+install_types = true
+non_interactive = true
+show_error_codes = true
+strict = true
 
 [tool.versioningit.vcs]
 method = "git"

--- a/tests/test_verlib2.py
+++ b/tests/test_verlib2.py
@@ -1,0 +1,13 @@
+import sys
+
+from verlib2 import __version__
+from verlib2.distutils.version import LooseVersion, StrictVersion
+from verlib2.packaging.version import Version
+
+
+def test_version():
+    if sys.version_info >= (3, 7):
+        assert Version("0.0.0") <= Version(__version__)
+    if sys.version_info >= (3, 8):
+        assert LooseVersion("0.0.0") <= __version__
+        assert StrictVersion("0.0.0") <= __version__

--- a/verlib2/__init__.py
+++ b/verlib2/__init__.py
@@ -10,10 +10,22 @@ __summary__ = (
 __uri__ = "https://github.com/pyveci/verlib2"
 __author__ = "Greg Ward, Donald Stufft, and individual contributors"
 
-__version__ = "0.1.0"
-
 __license__ = "BSD-2-Clause or Apache-2.0"
 __copyright__ = "2014 %s" % __author__
 
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except (ImportError, ModuleNotFoundError):  # pragma:nocover
+    from importlib_metadata import (  # type: ignore[assignment,no-redef,unused-ignore]
+        PackageNotFoundError,
+        version,
+    )
+
+__appname__ = "verlib2"
+
+try:
+    __version__ = version(__appname__)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
 
 from verlib2.packaging.version import Version  # noqa: F401


### PR DESCRIPTION
What the title says. `verlib2.__version__` was hard-coded to 0.1.0 before, which is wrong.