### PR TITLE
This and that

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,16 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.13"]
+        python-version: [
+          "3.6",
+          "3.7",
+          "3.8",
+          "3.9",
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+        ]
 
     env:
       OS: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
 ]
 
 optional-dependencies.develop = [
-  "black<26",
   "mypy<1.15",
   "poethepoet<1",
   "pyproject-fmt<2.6",
@@ -159,7 +158,7 @@ default-tag = "0.0.0"
 
 [tool.poe.tasks]
 format = [
-  { cmd = "black ." },
+  { cmd = "ruff format ." },
   # Configure Ruff not to auto-fix (remove!):
   # Ignore unused imports (F401), unused variables (F841), `print` statements (T201), and commented-out code (ERA001).
   { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001 ." },
@@ -167,8 +166,8 @@ format = [
 ]
 
 lint = [
+  { cmd = "ruff format --check ." },
   { cmd = "ruff check ." },
-  { cmd = "black --check ." },
   { cmd = "validate-pyproject pyproject.toml" },
   { cmd = "mypy" },
 ]

--- a/tests/test_verlib2.py
+++ b/tests/test_verlib2.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 from verlib2 import __version__
 from verlib2.distutils.version import LooseVersion, StrictVersion
 from verlib2.packaging.version import Version
@@ -10,4 +12,9 @@ def test_version():
         assert Version("0.0.0") <= Version(__version__)
     if sys.version_info >= (3, 8):
         assert LooseVersion("0.0.0") <= __version__
-        assert StrictVersion("0.0.0") <= __version__
+        if "+" in __version__:
+            with pytest.raises(ValueError) as ex:
+                _ = StrictVersion("0.0.0") <= __version__
+            assert ex.match("invalid version number")
+        else:
+            assert StrictVersion("0.0.0") <= __version__

--- a/tests/test_version_distutils.py
+++ b/tests/test_version_distutils.py
@@ -54,9 +54,9 @@ class TestVersion:
             res = StrictVersion(v1)._cmp(v2)
             assert res == wanted, f"cmp({v1}, {v2}) should be {wanted}, got {res}"
             res = StrictVersion(v1)._cmp(object())
-            assert (
-                res is NotImplemented
-            ), f"cmp({v1}, {v2}) should be NotImplemented, got {res}"
+            assert res is NotImplemented, (
+                f"cmp({v1}, {v2}) should be NotImplemented, got {res}"
+            )
 
     def test_cmp_loose(self):
         versions = (
@@ -76,9 +76,9 @@ class TestVersion:
             res = LooseVersion(v1)._cmp(v2)
             assert res == wanted, f"cmp({v1}, {v2}) should be {wanted}, got {res}"
             res = LooseVersion(v1)._cmp(object())
-            assert (
-                res is NotImplemented
-            ), f"cmp({v1}, {v2}) should be NotImplemented, got {res}"
+            assert res is NotImplemented, (
+                f"cmp({v1}, {v2}) should be NotImplemented, got {res}"
+            )
 
     def test_cmp_more(self):
         assert LooseVersion("1.5.1") < LooseVersion("1.5.2b2")

--- a/tests/test_version_packaging.py
+++ b/tests/test_version_packaging.py
@@ -627,9 +627,8 @@ class TestVersion:
         # Below we'll generate every possible combination of VERSIONS that
         # should be True for the given operator
         itertools.chain(
-            *
             # Verify that the less than (<) operator works correctly
-            [
+            *[
                 [(x, y, operator.lt) for y in VERSIONS[i + 1 :]]
                 for i, x in enumerate(VERSIONS)
             ]
@@ -670,9 +669,8 @@ class TestVersion:
         # Below we'll generate every possible combination of VERSIONS that
         # should be False for the given operator
         itertools.chain(
-            *
             # Verify that the less than (<) operator works correctly
-            [
+            *[
                 [(x, y, operator.lt) for y in VERSIONS[: i + 1]]
                 for i, x in enumerate(VERSIONS)
             ]

--- a/verlib2/distutils/version.py
+++ b/verlib2/distutils/version.py
@@ -53,7 +53,8 @@ class Version:
         if vstring:
             self.parse(vstring)
         warnings.warn(
-            "distutils Version classes are deprecated. Use packaging.version instead.",
+            "distutils Version classes are deprecated. "
+            "Use packaging.version or verlib2 instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/verlib2/packaging/version.py
+++ b/verlib2/packaging/version.py
@@ -459,7 +459,6 @@ class Version(_BaseVersion):
 def _parse_letter_version(
     letter: Optional[str], number: Union[str, bytes, SupportsInt, None]
 ) -> Optional[Tuple[str, int]]:
-
     if letter:
         # We consider there to be an implicit 0 in a pre-release if there is
         # not a numeral associated with it.
@@ -515,7 +514,6 @@ def _cmpkey(
     dev: Optional[Tuple[str, int]],
     local: Optional[LocalType],
 ) -> CmpKey:
-
     # When we compare a release version, we want to compare it with all of the
     # trailing zeros removed. So we'll use a reverse the list, drop all the now
     # leading zeros until we come to something non zero, then take the rest


### PR DESCRIPTION
- [CI: Validate on all available Python versions](https://github.com/pyveci/verlib2/commit/004d0670836b7e690e29f82847384fde7f6a47ea)
- [distutils: Update deprecation warning message, referring to verlib2](https://github.com/pyveci/verlib2/commit/1ac0c61a1f03a5b5f6dff682699a021cfebdba8c)
- [Linting: Remove Black. Ruff is excellent, and faster.](https://github.com/pyveci/verlib2/pull/62/commits/7348dd44f305a9237f38468a500f57f5314057a1)
- [distutils: Skip strict-parsing versions like 0.2.1.post3+g2cb3e](https://github.com/pyveci/verlib2/pull/62/commits/7ba3b8ca9ec1e2e1775ab909d7d68a522856094e)